### PR TITLE
Fix setCountClicks and setTransactional methods

### DIFF
--- a/src/Traits/ViberAddition.php
+++ b/src/Traits/ViberAddition.php
@@ -67,6 +67,8 @@ trait ViberAddition
     {
         if ($countClicks) {
             $this->countClicks = 1;
+        } else {
+            $this->countClicks = 0;
         }
 
         return $this;
@@ -80,6 +82,8 @@ trait ViberAddition
     {
         if ($isTransactional) {
             $this->isTransactional = 1;
+        } else {
+            $this->isTransactional = 0;
         }
 
         return $this;


### PR DESCRIPTION
When working through Octane or mass sending of different options, it is not possible to specify 0.